### PR TITLE
#15 - Add additional tests for SpeechKITT.displayRecognizedSentence()

### DIFF
--- a/test/spec/UISpec.js
+++ b/test/spec/UISpec.js
@@ -476,27 +476,9 @@
     });
 
     it('should create a span node', function() {
-      var getSpanChildren = function() {
-        return $("#skitt-listening-text").children("span");
-      };
-
       expect(getLastSentenceText()).toBeUndefined();
-
-      var startingChildren = getSpanChildren();
-      var startingChildCount = startingChildren.length;
-
       SpeechKITT.displayRecognizedSentence(true);
-
-      var endingChildren = getSpanChildren();
-      var endingChildCount = endingChildren.length;
-
-      expect(endingChildCount).toEqual(startingChildCount + 1);
-
-      var addedChildren = endingChildren.filter(startingChildren);
-
-      expect(addedChildren.length).toEqual(1);
-      expect($(addedChildren[0]).is("span")).toEqual(true);
-
+      expect(getLastSentenceTexts().is("span")).toEqual(true);
       SpeechKITT.displayRecognizedSentence(false);
     });
 

--- a/test/spec/UISpec.js
+++ b/test/spec/UISpec.js
@@ -475,6 +475,20 @@
       expect(getLastSentenceTexts()).toHaveLength(0);
     });
 
+    it('should create a span node', function() {
+      expect(getLastSentenceText()).toBeUndefined();
+      SpeechKITT.displayRecognizedSentence(true);
+      expect(getLastSentenceTexts().is("span")).toEqual(true);
+      SpeechKITT.displayRecognizedSentence(false);
+    });
+
+    it('should create the new node with the id `skitt-listening-text__recognized-sentence`', function() {
+      expect(getLastSentenceText()).toBeUndefined();
+      SpeechKITT.displayRecognizedSentence(true);
+      expect(getLastSentenceText()).toBeInDOM();
+      SpeechKITT.displayRecognizedSentence(false);
+    });
+
     it('should add the text of the last recognized sentence to the DOM even if turned on after it was said', function () {
       expect(getLastSentenceTexts()).toHaveLength(0);
       SpeechKITT.displayRecognizedSentence(true);

--- a/test/spec/UISpec.js
+++ b/test/spec/UISpec.js
@@ -476,9 +476,27 @@
     });
 
     it('should create a span node', function() {
+      var getSpanChildren = function() {
+        return $("#skitt-listening-text").children("span");
+      };
+
       expect(getLastSentenceText()).toBeUndefined();
+
+      var startingChildren = getSpanChildren();
+      var startingChildCount = startingChildren.length;
+
       SpeechKITT.displayRecognizedSentence(true);
-      expect(getLastSentenceTexts().is("span")).toEqual(true);
+
+      var endingChildren = getSpanChildren();
+      var endingChildCount = endingChildren.length;
+
+      expect(endingChildCount).toEqual(startingChildCount + 1);
+
+      var addedChildren = endingChildren.filter(startingChildren);
+
+      expect(addedChildren.length).toEqual(1);
+      expect($(addedChildren[0]).is("span")).toEqual(true);
+
       SpeechKITT.displayRecognizedSentence(false);
     });
 

--- a/test/spec/UISpec.js
+++ b/test/spec/UISpec.js
@@ -478,7 +478,7 @@
     it('should create a span node', function() {
       expect(getLastSentenceText()).toBeUndefined();
       SpeechKITT.displayRecognizedSentence(true);
-      expect(getLastSentenceTexts().is("span")).toEqual(true);
+      expect(getLastSentenceTexts().is('span')).toEqual(true);
       SpeechKITT.displayRecognizedSentence(false);
     });
 

--- a/test/spec/UISpec.js
+++ b/test/spec/UISpec.js
@@ -485,7 +485,8 @@
     it('should create the new node with the id `skitt-listening-text__recognized-sentence`', function() {
       expect(getLastSentenceText()).toBeUndefined();
       SpeechKITT.displayRecognizedSentence(true);
-      expect(getLastSentenceText()).toBeInDOM();
+      var expectedID = 'skitt-listening-text__recognized-sentence';
+      expect($(getLastSentenceText()).attr('id')).toEqual(expectedID);
       SpeechKITT.displayRecognizedSentence(false);
     });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Check that the new node created is a `span` element
- Check that the new node created has 'id' of 'skitt-listening-text__recognized-sentence'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue "Add test to verify SpeechKITT.displayRecognizedSentence() works well"
 - https://github.com/TalAter/SpeechKITT/issues/15

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running the Jasmine tests via grunt shows no errors or failing tests. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
