### PR TITLE
Add handling for non-string text arguments in SpeechKITT.setInstructionsText() (i.e. Fixes #6)

### DIFF
--- a/src/speechkitt.js
+++ b/src/speechkitt.js
@@ -39,7 +39,8 @@
 
   // Texts used in UI
   var _toggleLabelText = 'Activate Voice Control';
-  var _listeningInstructionsText = 'What can I help you with?';
+  var _defaultListeningInstructionsText = 'What can I help you with?';
+  var _listeningInstructionsText = _defaultListeningInstructionsText;
   var _sampleCommands = [];
 
   // A list of sentences recognized
@@ -466,8 +467,12 @@
      * @method setInstructionsText
      */
     setInstructionsText: function(text) {
-      _listeningInstructionsText = text;
-      _setText(text, 'skitt-listening-text__instructions');
+      if (typeof text === 'string') {
+        _listeningInstructionsText = text;
+        _setText(text, 'skitt-listening-text__instructions');
+      } else {
+        _listeningInstructionsText = _defaultListeningInstructionsText;
+      }
     },
 
     /**

--- a/test/spec/2_UISpec.js
+++ b/test/spec/2_UISpec.js
@@ -223,6 +223,14 @@
       Corti.unpatch();
     });
 
+    it('should use the default instructions with text "What can I help you with?"', function () {
+      expect(getInstructionsText().innerText).toEqual('What can I help you with?');
+      SpeechKITT.setInstructionsText();
+      expect(getInstructionsText().innerText).toEqual('What can I help you with?');
+      SpeechKITT.setInstructionsText(123456789);
+      expect(getInstructionsText().innerText).toEqual('What can I help you with?');
+    });
+
     it('should change the text of the listening instructions', function () {
       expect(getInstructionsText().innerText).toEqual('What can I help you with?');
       SpeechKITT.setInstructionsText('Talk to me Goose!');


### PR DESCRIPTION
## Description
Added `_defaultListeningInstructionsText` variable, and if a user calls `setInstructionsText()` without a string argument (e.g. ` SpeechKITT.setInstructionsText();` or `SpeechKITT.setInstructionsText(123456789);`), `_listeningInstructionsText` is set to `_defaultListeningInstructionsText;`

Added corresponding test.

## Motivation and Context
Fixes #6.

## How Has This Been Tested?
Following the contributing guide, tested via `grunt`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [(x)] Breaking change (fix or feature that would cause existing functionality to change)
  - *("In the sense that a user using non string instructions (e.g. integers) will now see the default instruction.")*

## Checklist:
- [x] My code follows the code style of this project.
  - *("I've done my best :-)")*
- [ ] My change requires a change to the documentation.
  - *"[Doc](https://github.com/TalAter/SpeechKITT/blob/master/docs/README.md#setinstructionstextstring) already clearly states the expected argument is a string."*
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
